### PR TITLE
Small QuoteModule Changes: iOS Smart Punctuation & static constants

### DIFF
--- a/src/main/java/com/wbigelow/ancillary/modules/QuoteModule.java
+++ b/src/main/java/com/wbigelow/ancillary/modules/QuoteModule.java
@@ -25,10 +25,10 @@ import java.util.List;
 public class QuoteModule implements Module {
 
     //The number of characters is ">quote ", ">addquote " and ">delquote ".
-    private final int QUOTE_LENGTH = 7;
-    private final int ADD_QUOTE_LENGTH = 10;
-    private final int DEL_QUOTE_LENGTH = 10;
-    private final String iOS_QUOTE_REGEX = "“|”";
+    private static final int QUOTE_LENGTH = 7;
+    private static final int ADD_QUOTE_LENGTH = 10;
+    private static final int DEL_QUOTE_LENGTH = 10;
+    private static final String iOS_QUOTE_REGEX = "“|”";
 
     
     public QuoteModule() {

--- a/src/main/java/com/wbigelow/ancillary/modules/QuoteModule.java
+++ b/src/main/java/com/wbigelow/ancillary/modules/QuoteModule.java
@@ -28,6 +28,7 @@ public class QuoteModule implements Module {
     private final int QUOTE_LENGTH = 7;
     private final int ADD_QUOTE_LENGTH = 10;
     private final int DEL_QUOTE_LENGTH = 10;
+    private final String iOS_QUOTE_REGEX = "“|”";
 
     
     public QuoteModule() {
@@ -137,7 +138,8 @@ public class QuoteModule implements Module {
         }
 
         private String addQuote(final Message message) {
-            final String[] content = message.getContent().substring(ADD_QUOTE_LENGTH).split("\""); // remove command
+            final String[] content = message.getContent().substring(ADD_QUOTE_LENGTH)
+                .replaceAll(iOS_QUOTE_REGEX, "\"").split("\""); // remove command
             if(content.length < 3) {
                 return "Please use the correct format: >addquote \"quote\" user";
             }


### PR DESCRIPTION
- Added a `replaceAll` for iOS autocorrected Smart Punctuation so that quotes from iOS work
![fail](https://user-images.githubusercontent.com/6354860/53624854-6d93cc00-3bb6-11e9-8b30-b08e74bf2200.png)
![pass](https://i.imgur.com/hKsmD40.png)
- Made class constants `static` (`private static final` as opposed to `private final`)